### PR TITLE
fix: package bundle naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-*
+* Package bundle naming
 
 ## [0.2.0] - 2021-12-14
 

--- a/package.json
+++ b/package.json
@@ -21,10 +21,10 @@
         "name": "Platforme",
         "url": "https://www.platforme.com"
     },
-    "main": "dist/invoice-express-api.cjs.js",
-    "unpkg": "dist/invoice-express-api.umd.js",
-    "module": "dist/invoice-express-api.esm.js",
-    "browser": "dist/invoice-express-api.umd.js",
+    "main": "dist/invoice-express-api-js.cjs.js",
+    "unpkg": "dist/invoice-express-api-js.umd.js",
+    "module": "dist/invoice-express-api-js.esm.js",
+    "browser": "dist/invoice-express-api-js.umd.js",
     "files": [
         "LICENSE",
         "dist/**/*",


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Linking did not work |
| Dependencies | -- |
| Decisions | - fix package bundle name - **the name contains `-js` because there was already a package `invoice-express-api` in npm**|
| Animated GIF | -- |